### PR TITLE
Drop support for Debian/stretch and releases older than bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Development of this setup is sponsored by [Sipwise](http://www.sipwise.com/).
 Involved Software
 -----------------
 
-* [Debian](https://www.debian.org/) (version 9/stretch, amd64)
+* [Debian](https://www.debian.org/) (amd64)
 * [Jenkins](https://jenkins.io/)
 * [jenkins-debian-glue](https://jenkins-debian-glue.org/)
 * [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/)

--- a/jjb/kamailio.yaml.in
+++ b/jjb/kamailio.yaml.in
@@ -44,7 +44,7 @@
     refspec: *refbranch
     branch: *branch
     browser_url: *browserurl
-    distributions: !!python/tuple [bookworm, bullseye, stretch, bionic, focal, jammy, noble]
+    distributions: !!python/tuple [bookworm, bullseye, bionic, focal, jammy, noble]
     architectures: *architectures
     jobs: *jobs_simple
     disabled: false
@@ -56,7 +56,7 @@
     refspec: *refbranch
     branch: 'refs/heads/6.0'
     browser_url: *browserurl
-    distributions: !!python/tuple [bookworm, bullseye, stretch, bionic, focal, jammy, noble]
+    distributions: !!python/tuple [bookworm, bullseye, bionic, focal, jammy, noble]
     architectures: *architectures
     jobs: *jobs_simple
     disabled: false
@@ -68,7 +68,7 @@
     refspec: *refbranch
     branch: 'refs/heads/5.8'
     browser_url: *browserurl
-    distributions: !!python/tuple [bookworm, bullseye, stretch, xenial, bionic, focal, jammy, noble]
+    distributions: !!python/tuple [bookworm, bullseye, xenial, bionic, focal, jammy, noble]
     architectures: *architectures
     jobs: *jobs_simple
     disabled: false
@@ -80,7 +80,7 @@
     refspec: *refbranch
     branch: 'refs/heads/5.7'
     browser_url: *browserurl
-    distributions: !!python/tuple [bookworm, bullseye, stretch, xenial, bionic, focal, jammy]
+    distributions: !!python/tuple [bookworm, bullseye, xenial, bionic, focal, jammy]
     architectures: *architectures
     jobs: *jobs_simple
     disabled: false
@@ -95,7 +95,7 @@
     refspec: *reftag
     branch: ':refs/tags/6\\.0\\.\\d+'
     browser_url: *browserurl
-    distributions: !!python/tuple [bookworm, bullseye, stretch, bionic, focal, jammy, noble]
+    distributions: !!python/tuple [bookworm, bullseye, bionic, focal, jammy, noble]
     architectures: *architectures
     jobs: *jobs_simple
     disabled: false
@@ -109,7 +109,7 @@
     refspec: *reftag
     branch: ':refs/tags/5\\.8\\.\\d+'
     browser_url: *browserurl
-    distributions: !!python/tuple [bookworm, bullseye, stretch, xenial, bionic, focal, jammy, noble]
+    distributions: !!python/tuple [bookworm, bullseye, xenial, bionic, focal, jammy, noble]
     architectures: *architectures
     jobs: *jobs_simple
     disabled: false
@@ -123,7 +123,7 @@
     refspec: *reftag
     branch: ':refs/tags/5\\.7\\.\\d+'
     browser_url: *browserurl
-    distributions: !!python/tuple [bookworm, bullseye, stretch, xenial, bionic, focal, jammy]
+    distributions: !!python/tuple [bookworm, bullseye, xenial, bionic, focal, jammy]
     architectures: *architectures
     jobs: *jobs_simple
     disabled: false

--- a/jjb/kamcli.yaml.in
+++ b/jjb/kamcli.yaml.in
@@ -53,7 +53,7 @@
     refspec: *reftag
     branch: ':refs/tags/v.*'
     browser_url: *browserurl
-    distributions: !!python/tuple [bullseye, stretch, focal, bionic, xenial]
+    distributions: !!python/tuple [bullseye, focal, bionic, xenial]
     jobs: *jobs_simple
     disabled: false
 

--- a/pbuilder/pbuilderrc
+++ b/pbuilder/pbuilderrc
@@ -37,32 +37,6 @@ case "$distribution" in
     # ensure it's unset
     unset LD_PRELOAD
     ;;
-  wheezy)
-    # nowadays resides on archive
-    MIRRORSITE="http://archive.debian.org/debian/"
-    # package install speedup
-    EXTRAPACKAGES="eatmydata"
-    export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}libeatmydata.so"
-    ;;
-  jessie)
-    # nowadays resides on archive
-    MIRRORSITE="http://archive.debian.org/debian/"
-    # security and updates
-    OTHERMIRROR="deb http://security.debian.org/debian-security ${distribution}/updates main"
-    # we need key id CBF8D6FD518E17E1
-    DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/debian-archive-removed-keys.gpg")
-    # package install speedup
-    EXTRAPACKAGES="eatmydata"
-    export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}libeatmydata.so"
-    ;;
-  stretch|buster)
-    MIRRORSITE="http://deb.debian.org/debian"
-    # security and updates
-    OTHERMIRROR="deb http://security.debian.org/debian-security ${distribution}/updates main"
-    # package install speedup
-    EXTRAPACKAGES="eatmydata"
-    export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}libeatmydata.so"
-    ;;
   bullseye)
     MIRRORSITE="http://deb.debian.org/debian"
     # security and updates

--- a/scripts/jdg-build-package
+++ b/scripts/jdg-build-package
@@ -29,10 +29,6 @@ case "$distribution" in
     export MIRRORSITE="http://old-releases.ubuntu.com/ubuntu/"
     echo "*** Building for Ubuntu release ${distribution}, using mirror $MIRRORSITE ***"
     ;;
-  jessie|wheezy)
-    export MIRRORSITE="http://archive.debian.org/debian/"
-    echo "*** Building for Debian release ${distribution}, using mirror $MIRRORSITE ***"
-    ;;
 esac
 
 # execute main jenkins-debian-glue script

--- a/scripts/jdg-generate-source
+++ b/scripts/jdg-generate-source
@@ -108,10 +108,6 @@ case "${distribution}" in
   focal)    BPO=ubuntu20.04 ;;
   jammy)    BPO=ubuntu22.04 ;;
   noble)    BPO=ubuntu24.04 ;;
-  wheezy)   BPO=bpo7 ;;
-  jessie)   BPO=bpo8 ;;
-  stretch)  BPO=bpo9 ;;
-  buster)   BPO=bpo10 ;;
   bullseye) BPO=bpo11 ;;
   bookworm) BPO=bpo12 ;;
   *)

--- a/scripts/rtpengine-profiles
+++ b/scripts/rtpengine-profiles
@@ -3,7 +3,6 @@ distribution=${distribution:-unknown}
 
 case "$distribution" in
   precise|trusty|xenial|bionic|focal) BUILD_PROFILES=pkg.rtpengine.no-transcoding ;;
-  wheezy|jessie|stretch|buster) BUILD_PROFILES=pkg.rtpengine.no-transcoding ;;
 esac
 
 echo "${BUILD_PROFILES:-}"


### PR DESCRIPTION
Debian/stretch (v9) is also EOL, so also get rid of it, and while at it also get rid of further leftovers from buster and even older Debian releases.

We support Debian bullseye and newer for now.