### PR TITLE
jenkins: update configuration to v2.516.1 + new AMI

### DIFF
--- a/jenkins/config.xml
+++ b/jenkins/config.xml
@@ -5,11 +5,11 @@
     <string>jenkins.monitor.JavaVersionRecommendationAdminMonitor</string>
     <string>OldData</string>
     <string>jenkins.monitor.JavaVersionRecommendationAdminMonitor-11-2024-09-30-WARNING</string>
-    <string>jenkins.model.BuiltInNodeMigration</string>
+    <string>hudson.util.DoubleLaunchChecker</string>
     <string>jenkins.security.s2m.MasterKillSwitchWarning</string>
     <string>jenkins.diagnostics.ControllerExecutorsAgents</string>
   </disabledAdministrativeMonitors>
-  <version>2.479.2</version>
+  <version>2.516.1</version>
   <numExecutors>2</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
@@ -28,14 +28,14 @@
   &#xd;
 &lt;p&gt;This is a public service, provided by &lt;a href=&quot;http://jenkins-debian-glue.org/&quot;&gt;jenkins-debian-glue&lt;/a&gt; and sponsored by &lt;a href=&quot;http://www.sipwise.com/&quot;&gt;Sipwise&lt;/a&gt;&lt;/h1&gt;&#xd;
 &lt;p&gt;Configuration (including deployment + scripts) available as &lt;a href=&quot;https://github.com/sipwise/kamailio-deb-jenkins&quot;&gt;kamailio-deb-jenkins&lt;/a&gt;.&lt;/p&gt;</systemMessage>
-  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter" plugin="antisamy-markup-formatter@162.v0e6ec0fcfcf6">
+  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter" plugin="antisamy-markup-formatter@173.v680e3a_b_69ff3">
     <disableSyntaxHighlighting>false</disableSyntaxHighlighting>
   </markupFormatter>
   <jdks/>
   <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
   <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
   <clouds>
-    <hudson.plugins.ec2.EC2Cloud plugin="ec2@1764.v71db_efb_46a_fe">
+    <hudson.plugins.ec2.EC2Cloud plugin="ec2@1994.v250f0efb_336a_">
       <name>ec2-eu-west-1</name>
       <useInstanceProfileForCredentials>false</useInstanceProfileForCredentials>
       <roleArn></roleArn>
@@ -45,268 +45,12 @@
       <instanceCap>10</instanceCap>
       <templates>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
-          <description>jenkins-debian-glue-slave buster</description>
-          <zone></zone>
-          <securityGroups>kamailio-jenkins-slave</securityGroups>
-          <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
-          <ebsOptimized>false</ebsOptimized>
-          <monitoring>false</monitoring>
-          <t2Unlimited>false</t2Unlimited>
-          <labels>slave:buster</labels>
-          <mode>EXCLUSIVE</mode>
-          <initScript>if [ -d /home/admin/kamailio-deb-jenkins ] ; then
-  cd /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-  git pull --rebase &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-else
-  git clone https://github.com/sipwise/kamailio-deb-jenkins.git /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-  sudo chown -R admin:admin /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-fi
-
-cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-sudo ./ec2/bootstrap.sh -u buster &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
-          <tmpDir></tmpDir>
-          <userData></userData>
-          <numExecutors>2</numExecutors>
-          <remoteAdmin>admin</remoteAdmin>
-          <javaPath>java</javaPath>
-          <jvmopts></jvmopts>
-          <subnetId>subnet-0cac724e3fcebdcda</subnetId>
-          <idleTerminationMinutes>30</idleTerminationMinutes>
-          <iamInstanceProfile></iamInstanceProfile>
-          <deleteRootOnTermination>false</deleteRootOnTermination>
-          <useEphemeralDevices>false</useEphemeralDevices>
-          <customDeviceMapping></customDeviceMapping>
-          <instanceCap>1</instanceCap>
-          <minimumNumberOfInstances>0</minimumNumberOfInstances>
-          <minimumNumberOfSpareInstances>0</minimumNumberOfSpareInstances>
-          <stopOnTerminate>false</stopOnTerminate>
-          <connectionStrategy>PUBLIC_IP</connectionStrategy>
-          <hostKeyVerificationStrategy>ACCEPT_NEW</hostKeyVerificationStrategy>
-          <associatePublicIp>true</associatePublicIp>
-          <amiType class="hudson.plugins.ec2.UnixData">
-            <rootCommandPrefix></rootCommandPrefix>
-            <slaveCommandPrefix></slaveCommandPrefix>
-            <slaveCommandSuffix></slaveCommandSuffix>
-            <sshPort>22</sshPort>
-            <bootDelay></bootDelay>
-          </amiType>
-          <launchTimeout>2147483647</launchTimeout>
-          <connectBySSHProcess>false</connectBySSHProcess>
-          <maxTotalUses>-1</maxTotalUses>
-          <nodeProperties/>
-          <nextSubnet>0</nextSubnet>
-          <tenancy>Default</tenancy>
-          <ebsEncryptRootVolume>DEFAULT</ebsEncryptRootVolume>
-          <metadataSupported>true</metadataSupported>
-          <metadataEndpointEnabled>true</metadataEndpointEnabled>
-          <metadataTokensRequired>false</metadataTokensRequired>
-          <metadataHopsLimit>1</metadataHopsLimit>
-          <amiOwners></amiOwners>
-          <amiUsers></amiUsers>
-          <usePrivateDnsName>false</usePrivateDnsName>
-          <connectUsingPublicIp>true</connectUsingPublicIp>
-        </hudson.plugins.ec2.SlaveTemplate>
-        <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
-          <description>jenkins-debian-glue-slave stretch</description>
-          <zone></zone>
-          <securityGroups>kamailio-jenkins-slave</securityGroups>
-          <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
-          <ebsOptimized>false</ebsOptimized>
-          <monitoring>false</monitoring>
-          <t2Unlimited>false</t2Unlimited>
-          <labels>slave:stretch</labels>
-          <mode>EXCLUSIVE</mode>
-          <initScript>if [ -d /home/admin/kamailio-deb-jenkins ] ; then
-  cd /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-  git pull --rebase &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-else
-  git clone https://github.com/sipwise/kamailio-deb-jenkins.git /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-  sudo chown -R admin:admin /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-fi
-
-cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-sudo ./ec2/bootstrap.sh -u stretch &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
-          <tmpDir></tmpDir>
-          <userData></userData>
-          <numExecutors>2</numExecutors>
-          <remoteAdmin>admin</remoteAdmin>
-          <javaPath>java</javaPath>
-          <jvmopts></jvmopts>
-          <subnetId>subnet-0cac724e3fcebdcda</subnetId>
-          <idleTerminationMinutes>30</idleTerminationMinutes>
-          <iamInstanceProfile></iamInstanceProfile>
-          <deleteRootOnTermination>false</deleteRootOnTermination>
-          <useEphemeralDevices>false</useEphemeralDevices>
-          <customDeviceMapping></customDeviceMapping>
-          <instanceCap>1</instanceCap>
-          <minimumNumberOfInstances>0</minimumNumberOfInstances>
-          <minimumNumberOfSpareInstances>0</minimumNumberOfSpareInstances>
-          <stopOnTerminate>false</stopOnTerminate>
-          <connectionStrategy>PUBLIC_IP</connectionStrategy>
-          <hostKeyVerificationStrategy>ACCEPT_NEW</hostKeyVerificationStrategy>
-          <associatePublicIp>true</associatePublicIp>
-          <amiType class="hudson.plugins.ec2.UnixData">
-            <rootCommandPrefix></rootCommandPrefix>
-            <slaveCommandPrefix></slaveCommandPrefix>
-            <slaveCommandSuffix></slaveCommandSuffix>
-            <sshPort>22</sshPort>
-            <bootDelay></bootDelay>
-          </amiType>
-          <launchTimeout>2147483647</launchTimeout>
-          <connectBySSHProcess>false</connectBySSHProcess>
-          <maxTotalUses>-1</maxTotalUses>
-          <nodeProperties/>
-          <nextSubnet>0</nextSubnet>
-          <tenancy>Default</tenancy>
-          <ebsEncryptRootVolume>DEFAULT</ebsEncryptRootVolume>
-          <metadataSupported>true</metadataSupported>
-          <metadataEndpointEnabled>true</metadataEndpointEnabled>
-          <metadataTokensRequired>false</metadataTokensRequired>
-          <metadataHopsLimit>1</metadataHopsLimit>
-          <amiOwners></amiOwners>
-          <amiUsers></amiUsers>
-          <usePrivateDnsName>false</usePrivateDnsName>
-          <connectUsingPublicIp>true</connectUsingPublicIp>
-        </hudson.plugins.ec2.SlaveTemplate>
-        <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
-          <description>jenkins-debian-glue-slave jessie</description>
-          <zone></zone>
-          <securityGroups>kamailio-jenkins-slave</securityGroups>
-          <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
-          <ebsOptimized>false</ebsOptimized>
-          <monitoring>false</monitoring>
-          <t2Unlimited>false</t2Unlimited>
-          <labels>slave:jessie</labels>
-          <mode>EXCLUSIVE</mode>
-          <initScript>if [ -d /home/admin/kamailio-deb-jenkins ] ; then
-  cd /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-  git pull --rebase &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-else
-  git clone https://github.com/sipwise/kamailio-deb-jenkins.git /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-  sudo chown -R admin:admin /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-fi
-
-cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-sudo ./ec2/bootstrap.sh -u jessie &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
-          <tmpDir></tmpDir>
-          <userData></userData>
-          <numExecutors>2</numExecutors>
-          <remoteAdmin>admin</remoteAdmin>
-          <javaPath>java</javaPath>
-          <jvmopts></jvmopts>
-          <subnetId>subnet-0cac724e3fcebdcda</subnetId>
-          <idleTerminationMinutes>30</idleTerminationMinutes>
-          <iamInstanceProfile></iamInstanceProfile>
-          <deleteRootOnTermination>false</deleteRootOnTermination>
-          <useEphemeralDevices>false</useEphemeralDevices>
-          <customDeviceMapping></customDeviceMapping>
-          <instanceCap>1</instanceCap>
-          <minimumNumberOfInstances>0</minimumNumberOfInstances>
-          <minimumNumberOfSpareInstances>0</minimumNumberOfSpareInstances>
-          <stopOnTerminate>false</stopOnTerminate>
-          <connectionStrategy>PUBLIC_IP</connectionStrategy>
-          <hostKeyVerificationStrategy>ACCEPT_NEW</hostKeyVerificationStrategy>
-          <associatePublicIp>true</associatePublicIp>
-          <amiType class="hudson.plugins.ec2.UnixData">
-            <rootCommandPrefix></rootCommandPrefix>
-            <slaveCommandPrefix></slaveCommandPrefix>
-            <slaveCommandSuffix></slaveCommandSuffix>
-            <sshPort>22</sshPort>
-            <bootDelay></bootDelay>
-          </amiType>
-          <launchTimeout>2147483647</launchTimeout>
-          <connectBySSHProcess>false</connectBySSHProcess>
-          <maxTotalUses>-1</maxTotalUses>
-          <nodeProperties/>
-          <nextSubnet>0</nextSubnet>
-          <tenancy>Default</tenancy>
-          <ebsEncryptRootVolume>DEFAULT</ebsEncryptRootVolume>
-          <metadataSupported>true</metadataSupported>
-          <metadataEndpointEnabled>true</metadataEndpointEnabled>
-          <metadataTokensRequired>false</metadataTokensRequired>
-          <metadataHopsLimit>1</metadataHopsLimit>
-          <amiOwners></amiOwners>
-          <amiUsers></amiUsers>
-          <usePrivateDnsName>false</usePrivateDnsName>
-          <connectUsingPublicIp>true</connectUsingPublicIp>
-        </hudson.plugins.ec2.SlaveTemplate>
-        <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
-          <description>jenkins-debian-glue-slave wheezy</description>
-          <zone></zone>
-          <securityGroups>kamailio-jenkins-slave</securityGroups>
-          <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
-          <ebsOptimized>false</ebsOptimized>
-          <monitoring>false</monitoring>
-          <t2Unlimited>false</t2Unlimited>
-          <labels>slave:wheezy</labels>
-          <mode>EXCLUSIVE</mode>
-          <initScript>if [ -d /home/admin/kamailio-deb-jenkins ] ; then
-  cd /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-  git pull --rebase &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-else
-  git clone https://github.com/sipwise/kamailio-deb-jenkins.git /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-  sudo chown -R admin:admin /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-fi
-
-cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
-sudo ./ec2/bootstrap.sh -u wheezy &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
-          <tmpDir></tmpDir>
-          <userData></userData>
-          <numExecutors>2</numExecutors>
-          <remoteAdmin>admin</remoteAdmin>
-          <javaPath>java</javaPath>
-          <jvmopts></jvmopts>
-          <subnetId>subnet-0cac724e3fcebdcda</subnetId>
-          <idleTerminationMinutes>30</idleTerminationMinutes>
-          <iamInstanceProfile></iamInstanceProfile>
-          <deleteRootOnTermination>false</deleteRootOnTermination>
-          <useEphemeralDevices>false</useEphemeralDevices>
-          <customDeviceMapping></customDeviceMapping>
-          <instanceCap>1</instanceCap>
-          <minimumNumberOfInstances>0</minimumNumberOfInstances>
-          <minimumNumberOfSpareInstances>0</minimumNumberOfSpareInstances>
-          <stopOnTerminate>false</stopOnTerminate>
-          <connectionStrategy>PUBLIC_IP</connectionStrategy>
-          <hostKeyVerificationStrategy>ACCEPT_NEW</hostKeyVerificationStrategy>
-          <associatePublicIp>true</associatePublicIp>
-          <amiType class="hudson.plugins.ec2.UnixData">
-            <rootCommandPrefix></rootCommandPrefix>
-            <slaveCommandPrefix></slaveCommandPrefix>
-            <slaveCommandSuffix></slaveCommandSuffix>
-            <sshPort>22</sshPort>
-            <bootDelay></bootDelay>
-          </amiType>
-          <launchTimeout>2147483647</launchTimeout>
-          <connectBySSHProcess>false</connectBySSHProcess>
-          <maxTotalUses>-1</maxTotalUses>
-          <nodeProperties/>
-          <nextSubnet>0</nextSubnet>
-          <tenancy>Default</tenancy>
-          <ebsEncryptRootVolume>DEFAULT</ebsEncryptRootVolume>
-          <metadataSupported>true</metadataSupported>
-          <metadataEndpointEnabled>true</metadataEndpointEnabled>
-          <metadataTokensRequired>false</metadataTokensRequired>
-          <metadataHopsLimit>1</metadataHopsLimit>
-          <amiOwners></amiOwners>
-          <amiUsers></amiUsers>
-          <usePrivateDnsName>false</usePrivateDnsName>
-          <connectUsingPublicIp>true</connectUsingPublicIp>
-        </hudson.plugins.ec2.SlaveTemplate>
-        <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
+          <ami>ami-0a33d7b1b7637c8ed</ami>
           <description>jenkins-debian-glue-slave trusty</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
           <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
+          <type>t3.large</type>
           <ebsOptimized>false</ebsOptimized>
           <monitoring>false</monitoring>
           <t2Unlimited>false</t2Unlimited>
@@ -324,7 +68,7 @@ cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
 sudo ./ec2/bootstrap.sh -u trusty &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
           <tmpDir></tmpDir>
           <userData></userData>
-          <numExecutors>2</numExecutors>
+          <numExecutors>4</numExecutors>
           <remoteAdmin>admin</remoteAdmin>
           <javaPath>java</javaPath>
           <jvmopts></jvmopts>
@@ -351,6 +95,7 @@ sudo ./ec2/bootstrap.sh -u trusty &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <launchTimeout>2147483647</launchTimeout>
           <connectBySSHProcess>false</connectBySSHProcess>
           <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
           <nodeProperties/>
           <nextSubnet>0</nextSubnet>
           <tenancy>Default</tenancy>
@@ -359,18 +104,19 @@ sudo ./ec2/bootstrap.sh -u trusty &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <metadataEndpointEnabled>true</metadataEndpointEnabled>
           <metadataTokensRequired>false</metadataTokensRequired>
           <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
           <amiOwners></amiOwners>
           <amiUsers></amiUsers>
           <usePrivateDnsName>false</usePrivateDnsName>
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
+          <ami>ami-0a33d7b1b7637c8ed</ami>
           <description>jenkins-debian-glue-slave xenial</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
           <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
+          <type>t3.large</type>
           <ebsOptimized>false</ebsOptimized>
           <monitoring>false</monitoring>
           <t2Unlimited>false</t2Unlimited>
@@ -388,7 +134,7 @@ cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
 sudo ./ec2/bootstrap.sh -u xenial &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
           <tmpDir></tmpDir>
           <userData></userData>
-          <numExecutors>2</numExecutors>
+          <numExecutors>4</numExecutors>
           <remoteAdmin>admin</remoteAdmin>
           <javaPath>java</javaPath>
           <jvmopts></jvmopts>
@@ -415,6 +161,7 @@ sudo ./ec2/bootstrap.sh -u xenial &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <launchTimeout>2147483647</launchTimeout>
           <connectBySSHProcess>false</connectBySSHProcess>
           <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
           <nodeProperties/>
           <nextSubnet>0</nextSubnet>
           <tenancy>Default</tenancy>
@@ -423,18 +170,19 @@ sudo ./ec2/bootstrap.sh -u xenial &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <metadataEndpointEnabled>true</metadataEndpointEnabled>
           <metadataTokensRequired>false</metadataTokensRequired>
           <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
           <amiOwners></amiOwners>
           <amiUsers></amiUsers>
           <usePrivateDnsName>false</usePrivateDnsName>
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
+          <ami>ami-0a33d7b1b7637c8ed</ami>
           <description>jenkins-debian-glue-slave bionic</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
           <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
+          <type>t3.large</type>
           <ebsOptimized>false</ebsOptimized>
           <monitoring>false</monitoring>
           <t2Unlimited>false</t2Unlimited>
@@ -452,7 +200,7 @@ cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
 sudo ./ec2/bootstrap.sh -u bionic &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
           <tmpDir></tmpDir>
           <userData></userData>
-          <numExecutors>2</numExecutors>
+          <numExecutors>4</numExecutors>
           <remoteAdmin>admin</remoteAdmin>
           <javaPath>java</javaPath>
           <jvmopts></jvmopts>
@@ -479,6 +227,7 @@ sudo ./ec2/bootstrap.sh -u bionic &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <launchTimeout>2147483647</launchTimeout>
           <connectBySSHProcess>false</connectBySSHProcess>
           <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
           <nodeProperties/>
           <nextSubnet>0</nextSubnet>
           <tenancy>Default</tenancy>
@@ -487,18 +236,19 @@ sudo ./ec2/bootstrap.sh -u bionic &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <metadataEndpointEnabled>true</metadataEndpointEnabled>
           <metadataTokensRequired>false</metadataTokensRequired>
           <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
           <amiOwners></amiOwners>
           <amiUsers></amiUsers>
           <usePrivateDnsName>false</usePrivateDnsName>
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
+          <ami>ami-0a33d7b1b7637c8ed</ami>
           <description>jenkins-debian-glue-slave focal</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
           <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
+          <type>t3.large</type>
           <ebsOptimized>false</ebsOptimized>
           <monitoring>false</monitoring>
           <t2Unlimited>false</t2Unlimited>
@@ -516,7 +266,7 @@ cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
 sudo ./ec2/bootstrap.sh -u focal &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
           <tmpDir></tmpDir>
           <userData></userData>
-          <numExecutors>2</numExecutors>
+          <numExecutors>4</numExecutors>
           <remoteAdmin>admin</remoteAdmin>
           <javaPath>java</javaPath>
           <jvmopts></jvmopts>
@@ -543,6 +293,7 @@ sudo ./ec2/bootstrap.sh -u focal &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <launchTimeout>2147483647</launchTimeout>
           <connectBySSHProcess>false</connectBySSHProcess>
           <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
           <nodeProperties/>
           <nextSubnet>0</nextSubnet>
           <tenancy>Default</tenancy>
@@ -551,18 +302,19 @@ sudo ./ec2/bootstrap.sh -u focal &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <metadataEndpointEnabled>true</metadataEndpointEnabled>
           <metadataTokensRequired>false</metadataTokensRequired>
           <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
           <amiOwners></amiOwners>
           <amiUsers></amiUsers>
           <usePrivateDnsName>false</usePrivateDnsName>
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
+          <ami>ami-0a33d7b1b7637c8ed</ami>
           <description>jenkins-debian-glue-slave bullseye</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
           <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
+          <type>t3.large</type>
           <ebsOptimized>false</ebsOptimized>
           <monitoring>false</monitoring>
           <t2Unlimited>false</t2Unlimited>
@@ -580,7 +332,7 @@ cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
 sudo ./ec2/bootstrap.sh -u bullseye &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
           <tmpDir></tmpDir>
           <userData></userData>
-          <numExecutors>2</numExecutors>
+          <numExecutors>4</numExecutors>
           <remoteAdmin>admin</remoteAdmin>
           <javaPath>java</javaPath>
           <jvmopts></jvmopts>
@@ -607,6 +359,7 @@ sudo ./ec2/bootstrap.sh -u bullseye &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScr
           <launchTimeout>2147483647</launchTimeout>
           <connectBySSHProcess>false</connectBySSHProcess>
           <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
           <nodeProperties/>
           <nextSubnet>0</nextSubnet>
           <tenancy>Default</tenancy>
@@ -615,18 +368,19 @@ sudo ./ec2/bootstrap.sh -u bullseye &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScr
           <metadataEndpointEnabled>true</metadataEndpointEnabled>
           <metadataTokensRequired>false</metadataTokensRequired>
           <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
           <amiOwners></amiOwners>
           <amiUsers></amiUsers>
           <usePrivateDnsName>false</usePrivateDnsName>
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
+          <ami>ami-0a33d7b1b7637c8ed</ami>
           <description>jenkins-debian-glue-slave bookworm</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
           <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
+          <type>t3.large</type>
           <ebsOptimized>false</ebsOptimized>
           <monitoring>false</monitoring>
           <t2Unlimited>false</t2Unlimited>
@@ -644,7 +398,7 @@ cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
 sudo ./ec2/bootstrap.sh -u bookworm &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
           <tmpDir></tmpDir>
           <userData></userData>
-          <numExecutors>2</numExecutors>
+          <numExecutors>4</numExecutors>
           <remoteAdmin>admin</remoteAdmin>
           <javaPath>java</javaPath>
           <jvmopts></jvmopts>
@@ -671,6 +425,7 @@ sudo ./ec2/bootstrap.sh -u bookworm &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScr
           <launchTimeout>2147483647</launchTimeout>
           <connectBySSHProcess>false</connectBySSHProcess>
           <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
           <nodeProperties/>
           <nextSubnet>0</nextSubnet>
           <tenancy>Default</tenancy>
@@ -679,18 +434,19 @@ sudo ./ec2/bootstrap.sh -u bookworm &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScr
           <metadataEndpointEnabled>true</metadataEndpointEnabled>
           <metadataTokensRequired>false</metadataTokensRequired>
           <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
           <amiOwners></amiOwners>
           <amiUsers></amiUsers>
           <usePrivateDnsName>false</usePrivateDnsName>
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
+          <ami>ami-0a33d7b1b7637c8ed</ami>
           <description>jenkins-debian-glue-slave jammy</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
           <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
+          <type>t3.large</type>
           <ebsOptimized>false</ebsOptimized>
           <monitoring>false</monitoring>
           <t2Unlimited>false</t2Unlimited>
@@ -708,7 +464,7 @@ cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
 sudo ./ec2/bootstrap.sh -u jammy &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
           <tmpDir></tmpDir>
           <userData></userData>
-          <numExecutors>2</numExecutors>
+          <numExecutors>4</numExecutors>
           <remoteAdmin>admin</remoteAdmin>
           <javaPath>java</javaPath>
           <jvmopts></jvmopts>
@@ -735,6 +491,7 @@ sudo ./ec2/bootstrap.sh -u jammy &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <launchTimeout>2147483647</launchTimeout>
           <connectBySSHProcess>false</connectBySSHProcess>
           <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
           <nodeProperties/>
           <nextSubnet>0</nextSubnet>
           <tenancy>Default</tenancy>
@@ -743,18 +500,19 @@ sudo ./ec2/bootstrap.sh -u jammy &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <metadataEndpointEnabled>true</metadataEndpointEnabled>
           <metadataTokensRequired>false</metadataTokensRequired>
           <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
           <amiOwners></amiOwners>
           <amiUsers></amiUsers>
           <usePrivateDnsName>false</usePrivateDnsName>
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0d4199032315bac68</ami>
+          <ami>ami-0a33d7b1b7637c8ed</ami>
           <description>jenkins-debian-glue-slave noble</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
           <remoteFS>/home/admin</remoteFS>
-          <type>T3Large</type>
+          <type>t3.large</type>
           <ebsOptimized>false</ebsOptimized>
           <monitoring>false</monitoring>
           <t2Unlimited>false</t2Unlimited>
@@ -772,7 +530,7 @@ cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
 sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
           <tmpDir></tmpDir>
           <userData></userData>
-          <numExecutors>2</numExecutors>
+          <numExecutors>4</numExecutors>
           <remoteAdmin>admin</remoteAdmin>
           <javaPath>java</javaPath>
           <jvmopts></jvmopts>
@@ -799,6 +557,7 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <launchTimeout>2147483647</launchTimeout>
           <connectBySSHProcess>false</connectBySSHProcess>
           <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
           <nodeProperties/>
           <nextSubnet>0</nextSubnet>
           <tenancy>Default</tenancy>
@@ -807,6 +566,7 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <metadataEndpointEnabled>true</metadataEndpointEnabled>
           <metadataTokensRequired>false</metadataTokensRequired>
           <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
           <amiOwners></amiOwners>
           <amiUsers></amiUsers>
           <usePrivateDnsName>false</usePrivateDnsName>
@@ -816,6 +576,7 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
       <region>eu-west-1</region>
       <altEC2Endpoint></altEC2Endpoint>
       <noDelayProvisioning>false</noDelayProvisioning>
+      <cleanUpOrphanedNodes>false</cleanUpOrphanedNodes>
     </hudson.plugins.ec2.EC2Cloud>
   </clouds>
   <quietPeriod>5</quietPeriod>
@@ -823,14 +584,15 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
   <views>
     <hudson.model.AllView>
       <owner class="hudson" reference="../../.."/>
-      <name>All</name>
+      <name>all</name>
       <filterExecutors>false</filterExecutors>
       <filterQueue>false</filterQueue>
       <properties class="hudson.model.View$PropertyList"/>
     </hudson.model.AllView>
     <listView>
       <owner class="hudson" reference="../../.."/>
-      <name>kam4.1</name>
+      <name>kamailio57</name>
+      <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
       <filterExecutors>false</filterExecutors>
       <filterQueue>false</filterQueue>
       <properties class="hudson.model.View$PropertyList"/>
@@ -847,12 +609,59 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
         <hudson.views.LastDurationColumn/>
         <hudson.views.BuildButtonColumn/>
       </columns>
-      <includeRegex>kamailio.*41.*</includeRegex>
+      <includeRegex>kamailio57.*</includeRegex>
       <recurse>false</recurse>
     </listView>
     <listView>
       <owner class="hudson" reference="../../.."/>
-      <name>kamdev</name>
+      <name>kamailio58</name>
+      <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+      <jobNames>
+        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
+      </jobNames>
+      <jobFilters/>
+      <columns>
+        <hudson.views.StatusColumn/>
+        <hudson.views.WeatherColumn/>
+        <hudson.views.JobColumn/>
+        <hudson.views.LastSuccessColumn/>
+        <hudson.views.LastFailureColumn/>
+        <hudson.views.LastDurationColumn/>
+        <hudson.views.BuildButtonColumn/>
+      </columns>
+      <includeRegex>kamailio58.*</includeRegex>
+      <recurse>false</recurse>
+    </listView>
+    <listView>
+      <owner class="hudson" reference="../../.."/>
+      <name>kamailio60</name>
+      <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+      <jobNames>
+        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
+      </jobNames>
+      <jobFilters/>
+      <columns>
+        <hudson.views.StatusColumn/>
+        <hudson.views.WeatherColumn/>
+        <hudson.views.JobColumn/>
+        <hudson.views.LastSuccessColumn/>
+        <hudson.views.LastFailureColumn/>
+        <hudson.views.LastDurationColumn/>
+        <hudson.views.BuildButtonColumn/>
+      </columns>
+      <includeRegex>kamailio60.*</includeRegex>
+      <recurse>false</recurse>
+    </listView>
+    <listView>
+      <owner class="hudson" reference="../../.."/>
+      <name>kamailiodev</name>
+      <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
       <filterExecutors>false</filterExecutors>
       <filterQueue>false</filterQueue>
       <properties class="hudson.model.View$PropertyList"/>
@@ -874,117 +683,8 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
     </listView>
     <listView>
       <owner class="hudson" reference="../../.."/>
-      <name>kam4.2</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio.*42.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam4.3</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio.*43.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam4.4</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio.*44.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.0</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio50.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.1</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio51.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
       <name>kamcli</name>
+      <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
       <filterExecutors>false</filterExecutors>
       <filterQueue>false</filterQueue>
       <properties class="hudson.model.View$PropertyList"/>
@@ -1001,34 +701,13 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
         <hudson.views.LastDurationColumn/>
         <hudson.views.BuildButtonColumn/>
       </columns>
-      <includeRegex>kamcli-.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.2</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio52.*</includeRegex>
+      <includeRegex>kamcli.*</includeRegex>
       <recurse>false</recurse>
     </listView>
     <listView>
       <owner class="hudson" reference="../../.."/>
       <name>rtpengine</name>
+      <description>&lt;!-- Managed by Jenkins Job Builder --&gt;</description>
       <filterExecutors>false</filterExecutors>
       <filterQueue>false</filterQueue>
       <properties class="hudson.model.View$PropertyList"/>
@@ -1048,140 +727,8 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
       <includeRegex>rtpengine.*</includeRegex>
       <recurse>false</recurse>
     </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.3</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio53.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.4</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio54.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.5</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="hudson.util.CaseInsensitiveComparator" reference="../../../listView/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio55.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.6</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="java.lang.String$CaseInsensitiveComparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio56.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.7</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="java.lang.String$CaseInsensitiveComparator" reference="../../../listView[14]/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio57.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
-    <listView>
-      <owner class="hudson" reference="../../.."/>
-      <name>kam5.8</name>
-      <filterExecutors>false</filterExecutors>
-      <filterQueue>false</filterQueue>
-      <properties class="hudson.model.View$PropertyList"/>
-      <jobNames>
-        <comparator class="java.lang.String$CaseInsensitiveComparator" reference="../../../listView[14]/jobNames/comparator"/>
-      </jobNames>
-      <jobFilters/>
-      <columns>
-        <hudson.views.StatusColumn/>
-        <hudson.views.WeatherColumn/>
-        <hudson.views.JobColumn/>
-        <hudson.views.LastSuccessColumn/>
-        <hudson.views.LastFailureColumn/>
-        <hudson.views.LastDurationColumn/>
-        <hudson.views.BuildButtonColumn/>
-      </columns>
-      <includeRegex>kamailio58.*</includeRegex>
-      <recurse>false</recurse>
-    </listView>
   </views>
-  <primaryView>kamdev</primaryView>
+  <primaryView>all</primaryView>
   <slaveAgentPort>0</slaveAgentPort>
   <label></label>
   <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
@@ -1190,5 +737,5 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
   <nodeProperties/>
   <globalNodeProperties/>
   <noUsageStatistics>true</noUsageStatistics>
-  <nodeRenameMigrationNeeded>true</nodeRenameMigrationNeeded>
+  <nodeRenameMigrationNeeded>false</nodeRenameMigrationNeeded>
 </hudson>


### PR DESCRIPTION
Current running Jenkins configuration, including switch to new AMI for our build env (debian 12.11 with fresh + current debian/ubuntu build envs (amd64 + arm64)).