### PR TITLE
Debian/trixie support on builder and build envs

### DIFF
--- a/ec2/bootstrap.sh
+++ b/ec2/bootstrap.sh
@@ -22,6 +22,7 @@ list_supported_distributions() {
     focal \
     jammy \
     noble \
+    trixie \
     trusty \
     xenial
   do
@@ -206,7 +207,7 @@ case "$distribution" in
     # ensure it's unset
     unset LD_PRELOAD
     ;;
-  bullseye|bookworm)
+  bullseye|bookworm|trixie)
     MIRRORSITE="http://deb.debian.org/debian"
     # security and updates
     OTHERMIRROR="deb http://security.debian.org/debian-security ${distribution}-security main"
@@ -274,6 +275,11 @@ fi
 
 if ! [ -e /usr/share/debootstrap/scripts/bookworm ] ; then
   echo "Debootstrap version doesn't know about Debian bookworm yet, creating according symlink"
+  ln -s sid /usr/share/debootstrap/scripts/sid
+fi
+
+if ! [ -e /usr/share/debootstrap/scripts/trixie ] ; then
+  echo "Debootstrap version doesn't know about Debian trixie yet, creating according symlink"
   ln -s sid /usr/share/debootstrap/scripts/sid
 fi
 

--- a/ec2/bootstrap.sh
+++ b/ec2/bootstrap.sh
@@ -70,19 +70,6 @@ systemctl disable unattended-upgrades.service
 export DEBIAN_FRONTEND=noninteractive
 export DEBIAN_PRIORITY=critical
 
-# enable j-d-g repos
-if [ -r /etc/apt/sources.list.d/jenkins-debian-glue.list ] ; then
-  echo "!!! /etc/apt/sources.list.d/jenkins-debian-glue.list exists already !!!"
-else
-  echo "deb     http://jenkins.grml.org/debian jenkins-debian-glue main" > /etc/apt/sources.list.d/jenkins-debian-glue.list
-fi
-
-if apt-key list | grep -q 52D4A654 ; then
-  echo "!!! GnuPG key 52D4A654 already listed in apt-key setup !!!"
-else
-  wget -O - http://jenkins.grml.org/debian/C525F56752D4A654.asc | apt-key add -
-fi
-
 install_ubuntu_keyring() {
   wget -O ubuntu-keyring_2021.03.26_all.deb \
     http://de.archive.ubuntu.com/ubuntu/pool/main/u/ubuntu-keyring/ubuntu-keyring_2021.03.26_all.deb


### PR DESCRIPTION
* ec2/bootstrap.sh: drop jenkins-debian-glue upstream repository
* ec2/bootstrap.sh: add support for Debian/trixie
