### PR TITLE
jenkins: update configuration to v2.516.3, new AMI + trixie template

### DIFF
--- a/jenkins/config.xml
+++ b/jenkins/config.xml
@@ -9,7 +9,7 @@
     <string>jenkins.security.s2m.MasterKillSwitchWarning</string>
     <string>jenkins.diagnostics.ControllerExecutorsAgents</string>
   </disabledAdministrativeMonitors>
-  <version>2.516.1</version>
+  <version>2.516.3</version>
   <numExecutors>2</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
@@ -35,7 +35,7 @@
   <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
   <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
   <clouds>
-    <hudson.plugins.ec2.EC2Cloud plugin="ec2@1994.v250f0efb_336a_">
+    <hudson.plugins.ec2.EC2Cloud plugin="ec2@2034.v0a_11fb_792b_ee">
       <name>ec2-eu-west-1</name>
       <useInstanceProfileForCredentials>false</useInstanceProfileForCredentials>
       <roleArn></roleArn>
@@ -45,7 +45,7 @@
       <instanceCap>10</instanceCap>
       <templates>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0a33d7b1b7637c8ed</ami>
+          <ami>ami-02565c0bd27d239b2</ami>
           <description>jenkins-debian-glue-slave trusty</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
@@ -74,6 +74,7 @@ sudo ./ec2/bootstrap.sh -u trusty &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <jvmopts></jvmopts>
           <subnetId>subnet-0cac724e3fcebdcda</subnetId>
           <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
           <iamInstanceProfile></iamInstanceProfile>
           <deleteRootOnTermination>false</deleteRootOnTermination>
           <useEphemeralDevices>false</useEphemeralDevices>
@@ -111,7 +112,7 @@ sudo ./ec2/bootstrap.sh -u trusty &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0a33d7b1b7637c8ed</ami>
+          <ami>ami-02565c0bd27d239b2</ami>
           <description>jenkins-debian-glue-slave xenial</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
@@ -140,6 +141,7 @@ sudo ./ec2/bootstrap.sh -u xenial &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <jvmopts></jvmopts>
           <subnetId>subnet-0cac724e3fcebdcda</subnetId>
           <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
           <iamInstanceProfile></iamInstanceProfile>
           <deleteRootOnTermination>false</deleteRootOnTermination>
           <useEphemeralDevices>false</useEphemeralDevices>
@@ -177,7 +179,7 @@ sudo ./ec2/bootstrap.sh -u xenial &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0a33d7b1b7637c8ed</ami>
+          <ami>ami-02565c0bd27d239b2</ami>
           <description>jenkins-debian-glue-slave bionic</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
@@ -206,6 +208,7 @@ sudo ./ec2/bootstrap.sh -u bionic &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <jvmopts></jvmopts>
           <subnetId>subnet-0cac724e3fcebdcda</subnetId>
           <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
           <iamInstanceProfile></iamInstanceProfile>
           <deleteRootOnTermination>false</deleteRootOnTermination>
           <useEphemeralDevices>false</useEphemeralDevices>
@@ -243,7 +246,7 @@ sudo ./ec2/bootstrap.sh -u bionic &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScrip
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0a33d7b1b7637c8ed</ami>
+          <ami>ami-02565c0bd27d239b2</ami>
           <description>jenkins-debian-glue-slave focal</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
@@ -272,6 +275,7 @@ sudo ./ec2/bootstrap.sh -u focal &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <jvmopts></jvmopts>
           <subnetId>subnet-0cac724e3fcebdcda</subnetId>
           <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
           <iamInstanceProfile></iamInstanceProfile>
           <deleteRootOnTermination>false</deleteRootOnTermination>
           <useEphemeralDevices>false</useEphemeralDevices>
@@ -309,7 +313,7 @@ sudo ./ec2/bootstrap.sh -u focal &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0a33d7b1b7637c8ed</ami>
+          <ami>ami-02565c0bd27d239b2</ami>
           <description>jenkins-debian-glue-slave bullseye</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
@@ -338,6 +342,7 @@ sudo ./ec2/bootstrap.sh -u bullseye &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScr
           <jvmopts></jvmopts>
           <subnetId>subnet-0cac724e3fcebdcda</subnetId>
           <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
           <iamInstanceProfile></iamInstanceProfile>
           <deleteRootOnTermination>false</deleteRootOnTermination>
           <useEphemeralDevices>false</useEphemeralDevices>
@@ -375,7 +380,7 @@ sudo ./ec2/bootstrap.sh -u bullseye &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScr
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0a33d7b1b7637c8ed</ami>
+          <ami>ami-02565c0bd27d239b2</ami>
           <description>jenkins-debian-glue-slave bookworm</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
@@ -404,6 +409,7 @@ sudo ./ec2/bootstrap.sh -u bookworm &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScr
           <jvmopts></jvmopts>
           <subnetId>subnet-0cac724e3fcebdcda</subnetId>
           <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
           <iamInstanceProfile></iamInstanceProfile>
           <deleteRootOnTermination>false</deleteRootOnTermination>
           <useEphemeralDevices>false</useEphemeralDevices>
@@ -441,7 +447,7 @@ sudo ./ec2/bootstrap.sh -u bookworm &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScr
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0a33d7b1b7637c8ed</ami>
+          <ami>ami-02565c0bd27d239b2</ami>
           <description>jenkins-debian-glue-slave jammy</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
@@ -470,6 +476,7 @@ sudo ./ec2/bootstrap.sh -u jammy &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <jvmopts></jvmopts>
           <subnetId>subnet-0cac724e3fcebdcda</subnetId>
           <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
           <iamInstanceProfile></iamInstanceProfile>
           <deleteRootOnTermination>false</deleteRootOnTermination>
           <useEphemeralDevices>false</useEphemeralDevices>
@@ -507,7 +514,7 @@ sudo ./ec2/bootstrap.sh -u jammy &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <connectUsingPublicIp>true</connectUsingPublicIp>
         </hudson.plugins.ec2.SlaveTemplate>
         <hudson.plugins.ec2.SlaveTemplate>
-          <ami>ami-0a33d7b1b7637c8ed</ami>
+          <ami>ami-02565c0bd27d239b2</ami>
           <description>jenkins-debian-glue-slave noble</description>
           <zone></zone>
           <securityGroups>kamailio-jenkins-slave</securityGroups>
@@ -536,6 +543,74 @@ sudo ./ec2/bootstrap.sh -u noble &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript
           <jvmopts></jvmopts>
           <subnetId>subnet-0cac724e3fcebdcda</subnetId>
           <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
+          <iamInstanceProfile></iamInstanceProfile>
+          <deleteRootOnTermination>false</deleteRootOnTermination>
+          <useEphemeralDevices>false</useEphemeralDevices>
+          <customDeviceMapping></customDeviceMapping>
+          <instanceCap>1</instanceCap>
+          <minimumNumberOfInstances>0</minimumNumberOfInstances>
+          <minimumNumberOfSpareInstances>0</minimumNumberOfSpareInstances>
+          <stopOnTerminate>false</stopOnTerminate>
+          <connectionStrategy>PUBLIC_IP</connectionStrategy>
+          <hostKeyVerificationStrategy>ACCEPT_NEW</hostKeyVerificationStrategy>
+          <associatePublicIp>true</associatePublicIp>
+          <amiType class="hudson.plugins.ec2.UnixData">
+            <rootCommandPrefix></rootCommandPrefix>
+            <slaveCommandPrefix></slaveCommandPrefix>
+            <slaveCommandSuffix></slaveCommandSuffix>
+            <sshPort>22</sshPort>
+            <bootDelay></bootDelay>
+          </amiType>
+          <launchTimeout>2147483647</launchTimeout>
+          <connectBySSHProcess>false</connectBySSHProcess>
+          <maxTotalUses>-1</maxTotalUses>
+          <avoidUsingOrphanedNodes>false</avoidUsingOrphanedNodes>
+          <nodeProperties/>
+          <nextSubnet>0</nextSubnet>
+          <tenancy>Default</tenancy>
+          <ebsEncryptRootVolume>DEFAULT</ebsEncryptRootVolume>
+          <metadataSupported>true</metadataSupported>
+          <metadataEndpointEnabled>true</metadataEndpointEnabled>
+          <metadataTokensRequired>false</metadataTokensRequired>
+          <metadataHopsLimit>1</metadataHopsLimit>
+          <enclaveEnabled>false</enclaveEnabled>
+          <amiOwners></amiOwners>
+          <amiUsers></amiUsers>
+          <usePrivateDnsName>false</usePrivateDnsName>
+          <connectUsingPublicIp>true</connectUsingPublicIp>
+        </hudson.plugins.ec2.SlaveTemplate>
+        <hudson.plugins.ec2.SlaveTemplate>
+          <ami>ami-02565c0bd27d239b2</ami>
+          <description>jenkins-debian-glue-slave trixie</description>
+          <zone></zone>
+          <securityGroups>kamailio-jenkins-slave</securityGroups>
+          <remoteFS>/home/admin</remoteFS>
+          <type>t3.large</type>
+          <ebsOptimized>false</ebsOptimized>
+          <monitoring>false</monitoring>
+          <t2Unlimited>false</t2Unlimited>
+          <labels>slave:trixie</labels>
+          <mode>EXCLUSIVE</mode>
+          <initScript>if [ -d /home/admin/kamailio-deb-jenkins ] ; then
+  cd /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
+  git pull --rebase &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
+else
+  git clone https://github.com/sipwise/kamailio-deb-jenkins.git /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
+  sudo chown -R admin:admin /home/admin/kamailio-deb-jenkins &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
+fi
+
+cd /home/admin/kamailio-deb-jenkins/ &gt;&gt;/tmp/initsh.log 2&gt;&amp;1
+sudo ./ec2/bootstrap.sh -u trixie &gt;&gt;/tmp/initsh.log 2&gt;&amp;1</initScript>
+          <tmpDir></tmpDir>
+          <userData></userData>
+          <numExecutors>4</numExecutors>
+          <remoteAdmin>admin</remoteAdmin>
+          <javaPath>java</javaPath>
+          <jvmopts></jvmopts>
+          <subnetId>subnet-0cac724e3fcebdcda</subnetId>
+          <idleTerminationMinutes>30</idleTerminationMinutes>
+          <terminateIdleDuringShutdown>false</terminateIdleDuringShutdown>
           <iamInstanceProfile></iamInstanceProfile>
           <deleteRootOnTermination>false</deleteRootOnTermination>
           <useEphemeralDevices>false</useEphemeralDevices>


### PR DESCRIPTION
Current running Jenkins configuration, including switch to new AMI for our build env (debian 13.1 on host, fresh + current debian/ubuntu build envs (amd64 + arm64)), and an additional new trixie template, to support building against Debian/trixie.